### PR TITLE
refactor(VConfirm): rename titlebar to header

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@
 module.exports = {
   root: true,
   env: {
+    es6: true,
     node: true,
   },
   extends: ["eslint:recommended"],

--- a/packages/docs/src/components/ComponentExample.vue
+++ b/packages/docs/src/components/ComponentExample.vue
@@ -291,7 +291,7 @@ export default Vue.extend({
   data() {
     return {
       dialog: false,
-      closeable: true,
+      closeable: false,
       persistent: false,
       noActionsDivider: false,
       dark: false,

--- a/packages/v-confirm/src/components/VConfirm/VConfirm.scss
+++ b/packages/v-confirm/src/components/VConfirm/VConfirm.scss
@@ -6,7 +6,7 @@
   > .v-confirm__content {
     background: map-get($theme, "background");
 
-    .v-confirm__titlebar {
+    .v-confirm__header {
       color: map-get($theme, "text-color");
 
       header {
@@ -71,20 +71,20 @@
   max-width: var.$v-confirm-content-max-width;
 }
 
-.v-confirm__titlebar {
+.v-confirm__header {
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  min-height: var.$v-confirm-titlebar-min-height;
-  padding: var.$v-confirm-titlebar-padding;
-  font-size: var.$v-confirm-titlebar-font-size;
-  font-weight: var.$v-confirm-titlebar-font-weight;
+  min-height: var.$v-confirm-header-min-height;
+  padding: var.$v-confirm-header-padding;
+  font-size: var.$v-confirm-header-font-size;
+  font-weight: var.$v-confirm-header-font-weight;
 
   .v-confirm__close-icon {
     display: flex;
     align-items: center;
-    min-height: var.$v-confirm-titlebar-icon-size;
-    min-width: var.$v-confirm-titlebar-icon-size;
+    min-height: var.$v-confirm-header-icon-size;
+    min-width: var.$v-confirm-header-icon-size;
   }
 }
 

--- a/packages/v-confirm/src/components/VConfirm/VConfirm.ts
+++ b/packages/v-confirm/src/components/VConfirm/VConfirm.ts
@@ -141,25 +141,25 @@ export default Themeable.extend({
           ],
         },
         [
-          this.genTitlebar(),
+          this.genHeader(),
           this.genMessage(),
           this.btns.length > 0 ? this.genActions() : null,
         ]
       );
     },
-    genTitlebar(): VNode {
+    genHeader(): VNode {
       const children: VNodeChildren = [];
-      const headerData = {
-        style: {
-          "background-color": "transparent",
-        },
-      };
-      const titlebar = this.$createElement(
-        "header",
-        setTextColor(this.titleTextColor, headerData),
-        this.title
+      children.push(
+        this.$createElement(
+          "header",
+          setTextColor(this.titleTextColor, {
+            style: {
+              "background-color": "transparent",
+            },
+          }),
+          this.title
+        )
       );
-      children.push(titlebar);
 
       if (this.closeable) {
         const spacer = this.$createElement("div", {
@@ -186,14 +186,13 @@ export default Themeable.extend({
         children.push(closeIcon);
       }
 
-      const titlebarData = {
-        class: {
-          "v-confirm__titlebar": true,
-        },
-      };
       return this.$createElement(
         "div",
-        setBackgroundColor(this.titleColor, titlebarData),
+        setBackgroundColor(this.titleColor, {
+          class: {
+            "v-confirm__header": true,
+          },
+        }),
         children
       );
     },

--- a/packages/v-confirm/src/components/VConfirm/__tests__/VConfirm.spec.ts
+++ b/packages/v-confirm/src/components/VConfirm/__tests__/VConfirm.spec.ts
@@ -13,10 +13,10 @@ describe("VConfirm.ts", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("not render a close icon in titlebar when default", () => {
+  it("not render a close icon in header when default", () => {
     const wrapper = mountFunc({ propsData: { value: true } });
     const closeIcon = wrapper.find(
-      ".v-confirm__titlebar > .v-confirm__close-icon"
+      ".v-confirm__header > .v-confirm__close-icon"
     );
     expect(wrapper.html()).toMatchSnapshot();
     expect(closeIcon.exists()).toBe(false);
@@ -25,7 +25,7 @@ describe("VConfirm.ts", () => {
   it("render a close icon when closeable is true", () => {
     const wrapper = mountFunc({ propsData: { value: true, closeable: true } });
     const closeIcon = wrapper.find(
-      ".v-confirm__titlebar > .v-confirm__close-icon"
+      ".v-confirm__header > .v-confirm__close-icon"
     );
     expect(wrapper.html()).toMatchSnapshot();
     expect(closeIcon.exists()).toBe(true);
@@ -53,7 +53,7 @@ describe("VConfirm.ts", () => {
 
   it("render a title text and background-color is inherit", () => {
     const wrapper = mountFunc({ propsData: { value: true, title: "title" } });
-    const title = wrapper.find(".v-confirm__titlebar");
+    const title = wrapper.find(".v-confirm__header");
     expect(wrapper.html()).toMatchSnapshot();
     expect(title.attributes().style).toContain("background-color: inherit");
   });
@@ -62,7 +62,7 @@ describe("VConfirm.ts", () => {
     const wrapper = mountFunc({
       propsData: { value: true, title: "title", titleColor: "#ffffff" },
     });
-    const title = wrapper.find(".v-confirm__titlebar");
+    const title = wrapper.find(".v-confirm__header");
     expect(wrapper.html()).toMatchSnapshot();
     expect(title.attributes().style).toContain(
       "background-color: rgb(255, 255, 255)"
@@ -73,7 +73,7 @@ describe("VConfirm.ts", () => {
     const wrapper = mountFunc({
       propsData: { value: true, title: "title", titleTextColor: "#ffffff" },
     });
-    const title = wrapper.find(".v-confirm__titlebar > header");
+    const title = wrapper.find(".v-confirm__header > header");
     expect(wrapper.html()).toMatchSnapshot();
     expect(title.attributes().style).toContain("color: rgb(255, 255, 255)");
   });

--- a/packages/v-confirm/src/components/VConfirm/__tests__/__snapshots__/VConfirm.spec.ts.snap
+++ b/packages/v-confirm/src/components/VConfirm/__tests__/__snapshots__/VConfirm.spec.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VConfirm.ts not render a close icon in titlebar when default 1`] = `
+exports[`VConfirm.ts not render a close icon in header when default 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -17,7 +17,7 @@ exports[`VConfirm.ts not render a divider when noActionsDivider is true 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -31,7 +31,7 @@ exports[`VConfirm.ts render a close icon when closeable is true 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
         <div class="v-confirm__spacer"></div>
         <div class="v-confirm__close-icon"><button type="button" class="mdi-icon light" style="width: 24px; height: 36px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" area-hidden="true" style="font-size: 24px; width: 24px; height: 24px; fill: currentColor; vertical-align: middle;">
@@ -48,7 +48,7 @@ exports[`VConfirm.ts render a dark component 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm dark">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -61,7 +61,7 @@ exports[`VConfirm.ts render a divider and actions when set the btns props 1`] = 
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -76,7 +76,7 @@ exports[`VConfirm.ts render a message text 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message">message</div>
@@ -89,7 +89,7 @@ exports[`VConfirm.ts render a title text and background-color is inherit 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;">title</header>
       </div>
       <div class="v-confirm__message"></div>
@@ -102,7 +102,7 @@ exports[`VConfirm.ts render a title with custom background-color 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: rgb(255, 255, 255);">
+      <div class="v-confirm__header" style="background-color: rgb(255, 255, 255);">
         <header style="background-color: transparent;">title</header>
       </div>
       <div class="v-confirm__message"></div>
@@ -115,7 +115,7 @@ exports[`VConfirm.ts render a title with custom text-color 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent; color: rgb(255, 255, 255);">title</header>
       </div>
       <div class="v-confirm__message"></div>
@@ -128,7 +128,7 @@ exports[`VConfirm.ts render dark divider 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm dark">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -143,7 +143,7 @@ exports[`VConfirm.ts render the action buttons 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -158,7 +158,7 @@ exports[`VConfirm.ts render the action buttons with class style background-color
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -173,7 +173,7 @@ exports[`VConfirm.ts render the action buttons with class style text color 1`] =
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -188,7 +188,7 @@ exports[`VConfirm.ts render the action buttons with css style background-color 1
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -203,7 +203,7 @@ exports[`VConfirm.ts render the action buttons with css style text color 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>
@@ -218,7 +218,7 @@ exports[`VConfirm.ts render when not active 1`] = `
 <transition-stub name="transition" appear="true">
   <div class="v-confirm light" style="display: none;">
     <div class="v-confirm__content" style="width: 800px;">
-      <div class="v-confirm__titlebar" style="background-color: inherit;">
+      <div class="v-confirm__header" style="background-color: inherit;">
         <header style="background-color: transparent;"></header>
       </div>
       <div class="v-confirm__message"></div>

--- a/packages/v-confirm/src/components/VConfirm/_variables.scss
+++ b/packages/v-confirm/src/components/VConfirm/_variables.scss
@@ -7,12 +7,12 @@ $v-confirm-content-border-radius: 3px !default;
 $v-confirm-content-box-shadow: 1px 2px 3px 4px rgba(12, 12, 12, 0.2) !default;
 $v-confirm-content-max-width: 95% !default;
 
-$v-confirm-titlebar-min-height: 36px !default;
-$v-confirm-titlebar-padding: 8px 12px !default;
-$v-confirm-titlebar-font-size: 24px !default;
-$v-confirm-titlebar-font-weight: bold !default;
+$v-confirm-header-min-height: 36px !default;
+$v-confirm-header-padding: 8px 12px !default;
+$v-confirm-header-font-size: 24px !default;
+$v-confirm-header-font-weight: bold !default;
 
-$v-confirm-titlebar-icon-size: 24px !default;
+$v-confirm-header-icon-size: 24px !default;
 
 $v-confirm-message-overflow-wrap: break-word !default;
 $v-confirm-message-white-space: pre-wrap !default;

--- a/packages/vetur-helper-json/src/index.js
+++ b/packages/vetur-helper-json/src/index.js
@@ -85,12 +85,7 @@ function parseProps(component, array = []) {
 }
 
 function writeJsonFile(obj, file) {
-  const stream = fs.createWriteStream(file);
-
-  stream.once("open", () => {
-    stream.write(JSON.stringify(obj, null, 2));
-    stream.end();
-  });
+  return fs.promises.writeFile(file, JSON.stringify(obj, null, 2));
 }
 
 const components = {};
@@ -147,14 +142,17 @@ if (!fs.existsSync("dist")) {
   fs.mkdirSync("dist", 0o755);
 }
 
-writeJsonFile(tags, "dist/tags.json");
-writeJsonFile(attributes, "dist/attributes.json");
-
-console.debug("pwd");
-shell.exec("pwd");
-shell.cp("./dist/tags.json", "../v-confirm/dist");
-shell.cp("./dist/attributes.json", "../v-confirm/dist");
-console.debug("ls");
-shell.exec("ls ../v-confirm/dist");
-
-console.debug("[vetur-helper-json:] generated tags.json and attributes.json");
+Promise.all([
+  writeJsonFile(tags, "dist/tags.json"),
+  writeJsonFile(attributes, "dist/attributes.json"),
+]).then(() => {
+  console.log("generated json file to dist");
+  if (shell.exec("ls ./dist/*.json").code === 0) {
+    shell.cp("./dist/tags.json", "../v-confirm/dist");
+    shell.cp("./dist/attributes.json", "../v-confirm/dist");
+    shell.exec("ls ../v-confirm/dist");
+    console.debug(
+      "[vetur-helper-json:] generated tags.json and attributes.json"
+    );
+  }
+});


### PR DESCRIPTION
## SCSS variables

- $v-confirm-titlebar-min-height -> $v-confirm-header-min-height
- $v-confirm-titlebar-padding -> $v-confirm-header-padding
- $v-confirm-titlebar-font-size -> $v-confirm-header-font-size
- $v-confirm-titlebar-font-weight -> $v-confirm-header-font-weight
- $v-confirm-titlebar-icon-size -> $v-confirm-header-icon-size

## CSS Class name

- .v-confirm__titlebar -> .v-confirm__header

## methods

- genTitlebar -> genHeader