### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gn5r/vue-confirm/security/code-scanning/15](https://github.com/gn5r/vue-confirm/security/code-scanning/15)

To fix the issue, add a `permissions` block at the root level of the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only performs linting and testing, the minimal required permission is `contents: read`. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
